### PR TITLE
V0.4.5

### DIFF
--- a/hypothesis.php
+++ b/hypothesis.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * @package Hypothesis
- * @version 0.4.1
+ * @version 0.4.5
  */
 /*
 Plugin Name: Hypothesis
 Plugin URI: http://hypothes.is/
 Description: Hypothesis is an open platform for the collaborative evaluation of knowledge. This plugin embeds the necessary scripts in your Wordpress site to enable any user to use Hypothesis without installing any extensions.
 Author: The Hypothesis Project and contributors
-Version: 0.4.1
+Version: 0.4.5
 Author URI: http://hypothes.is/
 */
 
@@ -193,6 +193,7 @@ class HypothesisSettingsPage
 
 		if( isset( $input['highlights-on-by-default'] ) )
 			$new_input['highlights-on-by-default'] = absint($input['highlights-on-by-default']);
+		// else $new_input['highlights-on-by-default'] = 1;
 
 		if( isset( $input['sidebar-open-by-default'] ) )
 			$new_input['sidebar-open-by-default'] = absint($input['sidebar-open-by-default']);
@@ -346,6 +347,14 @@ add_action('wp', 'add_hypothesis');
 
 function add_hypothesis($param) {
 	$options = get_option( 'wp_hypothesis_options' );
+
+	// Set defaults if we $options is not set yet.
+	if (empty($options)):
+		$defaults = array(
+		 'highlights-on-by-default' => 1,
+		);
+		add_option( 'wp_hypothesis_options', $defaults );
+	endif;
 
 	// Embed options
 	if (isset($options['highlights-on-by-default'])):

--- a/hypothesis.php
+++ b/hypothesis.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * @package Hypothesis
- * @version 0.4.0
+ * @version 0.4.1
  */
 /*
 Plugin Name: Hypothesis
 Plugin URI: http://hypothes.is/
 Description: Hypothesis is an open platform for the collaborative evaluation of knowledge. This plugin embeds the necessary scripts in your Wordpress site to enable any user to use Hypothesis without installing any extensions.
 Author: The Hypothesis Project and contributors
-Version: 0.4.0
+Version: 0.4.1
 Author URI: http://hypothes.is/
 */
 
@@ -349,11 +349,11 @@ function add_hypothesis($param) {
 
 	// Embed options
 	if (isset($options['highlights-on-by-default'])):
-		wp_enqueue_script( 'showhighlights', '/wp-content/plugins/wp-hypothesis/js/showhighlights.js', '', false, true );
+		wp_enqueue_script( 'showhighlights', '/wp-content/plugins/hypothesis/js/showhighlights.js', '', false, true );
 	endif;
 
 	if (isset($options['sidebar-open-by-default'])):
-		wp_enqueue_script( 'sidebaropen', '/wp-content/plugins/wp-hypothesis/js/sidebaropen.js', '', false, true );
+		wp_enqueue_script( 'sidebaropen', '/wp-content/plugins/hypothesis/js/sidebaropen.js', '', false, true );
 	endif;
 
 	// Content settings

--- a/license.txt
+++ b/license.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2014 Hypothes.is Project and contributors
+Copyright (c) 2013-2015 Hypothes.is Project and contributors
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: timmmmyboy, BigBlueHat, JakeHartnell
 Tags: hypothesis, annotation, comments
 Requires at least: 3.0.1
 Tested up to: 4.3
-Stable tag: 0.4.0
+Stable tag: 0.4.1
 License: BSD
 License URI: http://opensource.org/licenses/BSD-2-Clause
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: timmmmyboy, BigBlueHat, JakeHartnell
 Tags: hypothesis, annotation, comments
 Requires at least: 3.0.1
 Tested up to: 4.3
-Stable tag: 0.4.1
+Stable tag: 0.4.5
 License: BSD
 License URI: http://opensource.org/licenses/BSD-2-Clause
 


### PR DESCRIPTION
After trying to enable highlights on our own site, I realized the name of my folder had deviated from the plugin name. This PR fixes the path so it matches the plugin name and adds the ability to set default options.

Currently only show highlights is a default, but I was thinking of also enabling hypothesis on posts so that people could use the plugin without having to customize the settings... thoughts @BigBlueHat / @dwhly?

