### PR TITLE
Adding installation guidance to configure settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Stable versions are available on the
 3. Search the WordPress plugins directory for Hypothes.is
 4. Click Install Now.
 5. Click Activate
+6. Visit your WordPress Settings > Hypothesis page to configure how it works on your site
 
 ## Publishing
 


### PR DESCRIPTION
Suggesting another line in the WP plugin install guidance. I didn't see Hypothesis show up on my WP site until I figured out there were settings to configure.