### PR TITLE
Localize strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/vendor/
+node_modules
+vendor

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,43 @@
+module.exports = function( grunt ) {
+
+	'use strict';
+	var banner = '/**\n * <%= pkg.homepage %>\n * Copyright (c) <%= grunt.template.today("yyyy") %>\n * This file is generated automatically. Do not edit.\n */\n';
+	// Project configuration
+	grunt.initConfig( {
+
+		pkg: grunt.file.readJSON( 'package.json' ),
+
+		addtextdomain: {
+			options: {
+				textdomain: 'hypothesis',
+			},
+			target: {
+				files: {
+					src: [ '*.php', '**/*.php', '!node_modules/**', '!php-tests/**', '!bin/**' ]
+				}
+			}
+		},
+
+		makepot: {
+			target: {
+				options: {
+					domainPath: '/languages',
+					mainFile: 'hypothesis.php',
+					potFilename: 'hypothesis.pot',
+					potHeaders: {
+						poedit: true,
+						'x-poedit-keywordslist': true
+					},
+					type: 'wp-plugin',
+					updateTimestamp: true
+				}
+			}
+		},
+	} );
+
+	grunt.loadNpmTasks( 'grunt-wp-i18n' );
+	grunt.registerTask( 'i18n', ['addtextdomain', 'makepot'] );
+
+	grunt.util.linefeed = '\n';
+
+};

--- a/hypothesis.php
+++ b/hypothesis.php
@@ -1,17 +1,16 @@
 <?php
-/**
- * @package Hypothesis
- * @version 0.4.8
- */
-
 /*
-Plugin Name: Hypothesis
-Plugin URI: http://hypothes.is/
-Description: Hypothesis is an open platform for the collaborative evaluation of knowledge. This plugin embeds the necessary scripts in your Wordpress site to enable any user to use Hypothesis without installing any extensions.
-Author: The Hypothesis Project and contributors
-Version: 0.4.8
-Author URI: http://hypothes.is/
-*/
+ * Plugin Name: Hypothesis
+ * Plugin URI: http://hypothes.is/
+ * Description: Hypothesis is an open platform for the collaborative evaluation of knowledge. This plugin embeds the necessary scripts in your Wordpress site to enable any user to use Hypothesis without installing any extensions.
+ * Author: The Hypothesis Project and contributors
+ * Version: 0.4.8
+ * Author URI: http://hypothes.is/
+ * Text Domain:     hypothesis
+ * Domain Path:     /languages
+ *
+ * @package         Hypothesis
+ */
 
 // Exit if called directly.
 defined( 'ABSPATH' ) or die( 'Cannot access pages directly.' );
@@ -47,8 +46,8 @@ class HypothesisSettingsPage {
 	 */
 	public function add_plugin_page() {
 		add_options_page(
-			'Hypothesis Settings',
-			'Hypothesis',
+			__( 'Hypothesis Settings', 'hypothesis' ),
+			__( 'Hypothesis', 'hypothesis' ),
 			'manage_options',
 			'hypothesis-setting-admin',
 			array( $this, 'create_admin_page' )
@@ -62,8 +61,8 @@ class HypothesisSettingsPage {
 	 */
 	public static function get_posttypes() {
 		return apply_filters('hypothesis_supported_posttypes', array(
-			'post' => 'posts',
-			'page' => 'pages',
+			'post' => _x( 'posts', 'plural post type', 'hypothesis' ),
+			'page' => _x( 'pages', 'plural post type', 'hypothesis' ),
 		) );
 	}
 
@@ -101,14 +100,14 @@ class HypothesisSettingsPage {
 		 */
 		add_settings_section(
 			'hypothesis_settings_section', // ID.
-			'Hypothesis Settings', // Title.
+			__( 'Hypothesis Settings', 'hypothesis' ), // Title.
 			array( $this, 'settings_section_info' ), // Callback.
 			'hypothesis-setting-admin' // Page.
 		);
 
 		add_settings_field(
 			'highlights-on-by-default',
-			'Highlights on by default',
+			__( 'Highlights on by default', 'hypothesis' ),
 			array( $this, 'highlights_on_by_default_callback' ),
 			'hypothesis-setting-admin',
 			'hypothesis_settings_section'
@@ -116,7 +115,7 @@ class HypothesisSettingsPage {
 
 		add_settings_field(
 			'sidebar-open-by-default',
-			'Sidebar open by default',
+			__( 'Sidebar open by default', 'hypothesis' ),
 			array( $this, 'sidebar_open_by_default_callback' ),
 			'hypothesis-setting-admin',
 			'hypothesis_settings_section'
@@ -124,7 +123,7 @@ class HypothesisSettingsPage {
 
 		add_settings_field(
 			'serve-pdfs-with-via',
-			'Enable annotation for PDFs in Media Library',
+			__( 'Enable annotation for PDFs in Media Library', 'hypothesis' ),
 			array( $this, 'serve_pdfs_with_via_default_callback' ),
 			'hypothesis-setting-admin',
 			'hypothesis_settings_section'
@@ -136,14 +135,14 @@ class HypothesisSettingsPage {
 		 */
 		add_settings_section(
 			'hypothesis_content_section', // ID.
-			'Content Settings', // Title.
+			__( 'Content Settings', 'hypothesis' ), // Title.
 			array( $this, 'content_section_info' ), // Callback.
 			'hypothesis-setting-admin' // Page.
 		);
 
 		add_settings_field(
 			'allow-on-front-page',
-			'Allow on front page',
+			__( 'Allow on front page', 'hypothesis' ),
 			array( $this, 'allow_on_front_page_callback' ),
 			'hypothesis-setting-admin',
 			'hypothesis_content_section'
@@ -151,7 +150,7 @@ class HypothesisSettingsPage {
 
 		add_settings_field(
 			'allow-on-blog-page',
-			'Allow on blog page',
+			__( 'Allow on blog page', 'hypothesis' ),
 			array( $this, 'allow_on_blog_page_callback' ),
 			'hypothesis-setting-admin',
 			'hypothesis_content_section'
@@ -166,7 +165,7 @@ class HypothesisSettingsPage {
 
 			add_settings_field(
 				"allow-on-$slug",
-				"Allow on $name",
+				sprintf( __( 'Allow on %s', 'hypothesis' ), $name ),
 				array( $this, 'allow_on_posttype_callback' ),
 				'hypothesis-setting-admin',
 				'hypothesis_content_section',
@@ -180,7 +179,11 @@ class HypothesisSettingsPage {
 		foreach ( $posttypes as $slug => $name ) {
 			add_settings_field(
 				$slug . '_ids_show_h', // ID.
-				"Allow on specific $name (list of comma-separated $slug IDs, no spaces)", // Title.
+				sprintf(
+					__( 'Allow on specific %1$s (list of comma-separated %1$s IDs, no spaces)', 'hypothesis' ),
+					$name,
+					$slug
+				), // Title.
 				array( $this, 'posttype_ids_show_h_callback' ), // Callback.
 				'hypothesis-setting-admin', // Page.
 				'hypothesis_content_section', // Section.
@@ -194,7 +197,11 @@ class HypothesisSettingsPage {
 		foreach ( $posttypes as $slug => $name ) {
 			add_settings_field(
 				$slug . '_ids_override', // ID.
-				"Disallow on specific $name (list of comma-separated $slug IDs, no spaces)", // Title.
+				sprintf(
+					__( 'Disallow on specific %1$s (list of comma-separated %1$s IDs, no spaces)', 'hypothesis' ),
+					$name,
+					$slug
+				), // Title.
 				array( $this, 'posttype_ids_override_callback' ), // Callback.
 				'hypothesis-setting-admin', // Page.
 				'hypothesis_content_section', // Section.
@@ -252,11 +259,11 @@ class HypothesisSettingsPage {
 				$slug = 'page';
 			}
 
-			if ( isset( $input[ $slug . '_ids_show_h' ] ) ) {
+			if ( isset( $input[ $slug . '_ids_show_h' ] ) && '' != $input[ $slug . '_ids_show_h' ] ) {
 				$new_input[ $slug . '_ids_show_h' ] = explode( ',', esc_attr( $input[ $slug . '_ids_show_h' ] ) );
 			}
 
-			if ( isset( $input[ $slug . '_ids_override' ] ) ) {
+			if ( isset( $input[ $slug . '_ids_override' ] ) && '' != $input[ $slug . '_ids_override' ] ) {
 				$new_input[ $slug . '_ids_override' ] = explode( ',', esc_attr( $input[ $slug . '_ids_override' ] ) );
 			}
 		}
@@ -268,15 +275,17 @@ class HypothesisSettingsPage {
 	 * Print the Hypothesis Settings section text
 	 */
 	public function settings_section_info() {
-		print 'Customize Hypothesis defaults and behavior.';
-	}
+	?>
+		<p><?php esc_attr_e( 'Customize Hypothesis defaults and behavior.', 'hypothesis' ); ?></p>
+	<?php }
 
 	/**
 	 * Print the Content Settings section text
 	 */
 	public function content_section_info() {
-		print 'Control where Hypothesis is loaded.';
-	}
+	?>
+		<p><?php esc_attr_e( 'Control where Hypothesis is loaded.', 'hypothesis' ); ?></p>
+	<?php }
 
 	/**
 	 * Callback for 'highlights-on-by-default'.

--- a/languages/hypothesis.pot
+++ b/languages/hypothesis.pot
@@ -1,0 +1,102 @@
+# Copyright (C) 2016 The Hypothesis Project and contributors
+# This file is distributed under the same license as the Hypothesis package.
+msgid ""
+msgstr ""
+"Project-Id-Version: Hypothesis 0.4.8\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/hypothesis\n"
+"POT-Creation-Date: 2016-12-05 14:07:56+00:00\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2016-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"X-Generator: grunt-wp-i18n 0.5.4\n"
+"X-Poedit-KeywordsList: "
+"__;_e;_x:1,2c;_ex:1,2c;_n:1,2;_nx:1,2,4c;_n_noop:1,2;_nx_noop:1,2,3c;esc_"
+"attr__;esc_html__;esc_attr_e;esc_html_e;esc_attr_x:1,2c;esc_html_x:1,2c;\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Poedit-Country: United States\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-Basepath: ../\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-Bookmarks: \n"
+"X-Textdomain-Support: yes\n"
+
+#: hypothesis.php:49 hypothesis.php:103
+msgid "Hypothesis Settings"
+msgstr ""
+
+#. Plugin Name of the plugin/theme
+msgid "Hypothesis"
+msgstr ""
+
+#: hypothesis.php:110
+msgid "Highlights on by default"
+msgstr ""
+
+#: hypothesis.php:118
+msgid "Sidebar open by default"
+msgstr ""
+
+#: hypothesis.php:126
+msgid "Enable annotation for PDFs in Media Library"
+msgstr ""
+
+#: hypothesis.php:138
+msgid "Content Settings"
+msgstr ""
+
+#: hypothesis.php:145
+msgid "Allow on front page"
+msgstr ""
+
+#: hypothesis.php:153
+msgid "Allow on blog page"
+msgstr ""
+
+#: hypothesis.php:168
+msgid "Allow on %s"
+msgstr ""
+
+#: hypothesis.php:183
+msgid "Allow on specific %1$s (list of comma-separated %1$s IDs, no spaces)"
+msgstr ""
+
+#: hypothesis.php:201
+msgid "Disallow on specific %1$s (list of comma-separated %1$s IDs, no spaces)"
+msgstr ""
+
+#: hypothesis.php:279
+msgid "Customize Hypothesis defaults and behavior."
+msgstr ""
+
+#: hypothesis.php:287
+msgid "Control where Hypothesis is loaded."
+msgstr ""
+
+#. Author URI of the plugin/theme
+msgid "http://hypothes.is/"
+msgstr ""
+
+#. Description of the plugin/theme
+msgid ""
+"Hypothesis is an open platform for the collaborative evaluation of "
+"knowledge. This plugin embeds the necessary scripts in your Wordpress site "
+"to enable any user to use Hypothesis without installing any extensions."
+msgstr ""
+
+#. Author of the plugin/theme
+msgid "The Hypothesis Project and contributors"
+msgstr ""
+
+#: hypothesis.php:64
+msgctxt "plural post type"
+msgid "posts"
+msgstr ""
+
+#: hypothesis.php:65
+msgctxt "plural post type"
+msgid "pages"
+msgstr ""

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+
+{
+  "name": "hypothesis",
+  "version": "0.4.8",
+  "main": "Gruntfile.js",
+  "author": "The Hypothesis Project and contributors",
+  "repository": "http://github.com/hypothesis/wp-hypothesis/",
+  "license": "BSD-2-Clause",
+  "devDependencies": {
+    "grunt": "~0.4.5",
+    "grunt-wp-i18n": "~0.5.0"
+  }
+}


### PR DESCRIPTION
This pull request wraps all UI strings in localization functions, adds the Grunt `i18n` task (which generates/updates a `.pot` file for localization). To update the `.pot` file (found in `/languages/hypothesis.pot`), run the following from within the plugin directory:

```
npm install && grunt i18n
```