### PR TITLE
via-pdf regular expression should be Multisite-friendly.

### DIFF
--- a/hypothesis.php
+++ b/hypothesis.php
@@ -442,6 +442,11 @@ function add_hypothesis() {
 
 	if ( isset( $options['serve-pdfs-with-via'] ) ) :
 		wp_enqueue_script( 'pdfs-with-via', plugins_url( 'js/via-pdf.js', __FILE__ ), array(), false, true );
+
+		$uploads = wp_upload_dir();
+		wp_localize_script( 'pdfs-with-via', 'HypothesisPDF', array(
+			'uploadsBase' => trailingslashit( $uploads['baseurl'] ),
+		) );
 	endif;
 
 	// Content settings.

--- a/js/via-pdf.js
+++ b/js/via-pdf.js
@@ -1,7 +1,7 @@
 var anchors = document.getElementsByTagName('a');
-var re = /wp-content\/uploads[.+]\.pdf/;
+var hypRe = new RegExp( HypothesisPDF.uploadsBase + '.+\.pdf', 'i' );
 for ( i=0; i<anchors.length; i++ ) {
    var href = anchors[i].href;
-   if ( href.match(/wp-content\/uploads.+\.pdf/i) ) 
+   if ( href.match(hypRe) )
        anchors[i].href = 'https://via.hypothes.is/' + anchors[i].href;
   }


### PR DESCRIPTION
The regular expression used to swap out PDF links is hardcoded: `wp-content/uploads.+\.pdf`. This doesn't work on all installations. In Multisite, as well as in other customized setups, the upload directory (and, more importantly, the public URL of the upload directory) is different. Sometimes it's `example.com/files`, sometimes `example.com/wp-content/sites`, etc.

This PR uses `wp_upload_dir()` to (dynamically) fetch the base URL for the upload directory, and then uses that base to build the regular expression.

A small note that this change means that the regex checks for absolute `href` URLs, so won't catch relative URLs in the same way that your old one will. (It's quite a bit more complicated to write a relative-URL-sensitive regex that works on all WP setups.) But WP should always use absolute URLs when generating anchor markup from the Media Library, so it shouldn't be an issue.