### PR TITLE
Add a basic Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.PHONY: default
+default: help
+
+.PHONY: help
+help:
+	@echo "make help     Show this help message"
+	@echo "make dev      Run the plugin in the development WordPress"
+	@echo "make lint     Run the code linter(s) and print any warnings"
+	@echo "make format   Automatically format code"
+	@echo "make sure     Make sure that the formatter, linter, tests, etc all pass"
+
+.PHONY: dev
+dev: vendor
+	docker compose up
+
+.PHONY: lint
+lint: vendor
+	composer lint
+
+.PHONY: format
+format: vendor
+	composer format
+
+.PHONY: sure
+sure: lint
+
+vendor: composer.json composer.lock
+	composer install

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Stable versions are available on the [Hypothesis plugin page on WordPress.org](https://wordpress.org/plugins/hypothesis/).
 
-## Install Directions
+## Install this plugin
 
 1. Visit your WordPress plugins page (/wp-admin/plugins.php)
 2. Click the Add New button
@@ -10,6 +10,13 @@ Stable versions are available on the [Hypothesis plugin page on WordPress.org](h
 4. Click Install Now.
 5. Click Activate
 6. Visit your WordPress Settings > Hypothesis page to configure how it works on your site
+
+## Development
+
+1. Install `php` and the `dom` and `mbstring` extensions.
+2. [Download Composer](https://getcomposer.org/download/), the PHP package manager.
+3. Run `make dev`. This will start a local WordPress instance with this plugin mounted on it.
+4. Access http://localhost:8080 (the first time you'll have to finish setting up WordPress by following presented instructions)
 
 ## Publishing
 


### PR DESCRIPTION
Part of https://github.com/hypothesis/wp-hypothesis/issues/40

Add a very basic `Makefile`, which follows the usual tasks we have in other projects.

The only exception are tasks around testing, as there are no tests yet. We can add tasks related with tests as part of adding the tests themselves.