### PR TITLE
Add wp-cli.phar file to distignore

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -11,3 +11,4 @@ package.json
 package-lock.json
 phpcs.xml
 vendor
+wp-cli.phar


### PR DESCRIPTION
We download the wp-cli during releases in order to perform some actions, so it needs to be distignored or it is packaged with the rest of the files.