### PR TITLE
Prepare for packagist.org publishing

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,6 +1,7 @@
 .distignore
 .editorconfig
 .git
+.gitattributes
 .github
 .gitignore
 composer.json

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+.distignore export-ignore
+.github export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+composer.lock export-ignore
+docker-compose.yml export-ignore
+package-lock.lock export-ignore
+phpcs.xml export-ignore

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Stable versions are available on the [Hypothesis plugin page on WordPress.org](h
 
 ## Install this plugin
 
+### Via composer
+
+This plugin can be installed with composer, from the standard package registry (packagist.org)
+
+    composer require hypothesis/wp-hypothesis
+
+### Via WordPress plugins directory
+
 1. Visit your WordPress plugins page (/wp-admin/plugins.php)
 2. Click the Add New button
 3. Search the WordPress plugins directory for Hypothes.is
@@ -26,6 +34,9 @@ Follow these steps to publish a new plugin version.
 2. **Update readme.txt**, adding the new version with its list of changes, under the `Changelog` section.
 3. **Merge** the changes into the `main` branch[^1]. We use [Semantic Versioning](https://semver.org/#semantic-versioning-200).
 4. **Create a tag** pointing at the version-change commit and generate a **new GitHub release** (details follow). Publishing a GitHub release will kick off a GitHub Action that will publish the plugin to wordpress.org
+
+> [!NOTE]
+> The package will be automatically published in packagist.org just by pushing the new git tag.
 
 ### Creating a GitHub release
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "hypothesis/hypothesis",
+    "name": "hypothesis/wp-hypothesis",
     "description": "An open platform for the collaborative evaluation of knowledge.",
     "homepage": "https://github.com/hypothesis/wp-hypothesis",
     "support": {


### PR DESCRIPTION
Part of #52 

The standard package manager for PHP projects is [composer](https://getcomposer.org/), and packagist.org is its package registry. Many WordPress projects handled by more technical people use composer to manage dependencies, including WordPress plugins.

This PR adds the needed config changes and documentation so that we can publish this plugin there, and people can install it via `composer require hypothesis/hypothesis-wp-plugin`. This is the equivalent to `yarn add @hypothesis/frontend-shared`, for example.

Composer defers a bit from other languages package managers, in which the registry only stores metadata, but code itself is installed via git, mercurial, subversion, etc.

However, when installing dependencies for production, you usually pass `--prefer-dist` (which is actually the default), which in the case of git makes it use `git archive` and honor the `.gitattributes` file.

### Next steps

Once this is merged, when need to "link" this repository in packagist.org, making it available for install, and ensuring any new git tag will be automatically synced there.