### PR TITLE
Fix guideline issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ Create a [new GitHub release](https://github.com/hypothesis/wp-hypothesis/releas
 
 ## License
 
-[BSD](http://opensource.org/licenses/BSD-2-Clause)
+[BSD-2-Clause](http://opensource.org/licenses/BSD-2-Clause)

--- a/class-hypothesissettingspage.php
+++ b/class-hypothesissettingspage.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Hypothesis;
+
 /**
  * Create settings page (see https://codex.wordpress.org/Creating_Options_Pages)
  */

--- a/hypothesis.php
+++ b/hypothesis.php
@@ -8,7 +8,7 @@
  * Requires PHP: 7.4
  * Author: The Hypothesis Project and contributors
  * Author URI: https://hypothes.is/
- * License: BSD
+ * License: BSD-2-Clause
  * License URI: https://opensource.org/licenses/BSD-2-Clause
  * Text Domain: hypothesis
  * Domain Path: /languages

--- a/hypothesis.php
+++ b/hypothesis.php
@@ -14,14 +14,24 @@
  * Domain Path: /languages
  **/
 
+namespace Hypothesis;
+
+use function add_action;
+use function define;
+use function defined;
+use function get_option;
+use function is_admin;
+use function load_plugin_textdomain as wp_load_plugin_textdomain;
+use function wp_enqueue_script;
+
 // Exit if called directly.
 defined( 'ABSPATH' ) || die( 'Cannot access pages directly.' );
 
 // Load textdomain
-function hypothesis_load_plugin_textdomain() {
-	load_plugin_textdomain( 'hypothesis', false, basename( __DIR__ ) . '/languages/' );
+function load_plugin_textdomain() {
+	wp_load_plugin_textdomain( 'hypothesis', false, basename( __DIR__ ) . '/languages/' );
 }
-add_action( 'plugins_loaded', 'hypothesis_load_plugin_textdomain' );
+add_action( 'plugins_loaded', 'Hypothesis\load_plugin_textdomain' );
 
 define( 'HYPOTHESIS_PLUGIN_VERSION', '0.7.1' );
 
@@ -34,7 +44,7 @@ if ( is_admin() ) {
 /**
  * Add Hypothesis based on conditions set in the plugin settings.
  */
-add_action( 'wp', 'add_hypothesis' );
+add_action( 'wp', 'Hypothesis\add_scripts' );
 
 /**
  * Wrapper for the primary Hypothesis wp_enqueue call.
@@ -46,7 +56,7 @@ function enqueue_hypothesis() {
 /**
  * Add Hypothesis script(s) to front end.
  */
-function add_hypothesis() {
+function add_scripts() {
 	$options   = get_option( 'wp_hypothesis_options' );
 	$posttypes = HypothesisSettingsPage::get_posttypes();
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: hypothesis, annotation, comments
 Requires at least: 6.2
 Tested up to: 6.4.2
 Stable tag: 0.7.1
-License: BSD
+License: BSD-2-Clause
 License URI: http://opensource.org/licenses/BSD-2-Clause
 
 An open platform for the collaborative evaluation of knowledge.

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,13 @@ An open platform for the collaborative evaluation of knowledge.
 
 Hypothesis is a web annotation tool that allows users to provide commentary, references, and insight on top of news, blogs, scientific articles, books, terms of service, ballot initiatives, legislation and regulations, software code and more. You can find out more at [http://hypothes.is/](http://hypothes.is/)
 
+This plugin will allow you to automatically embed Hypothesis in your site, and integrate with the Hypothesis annotations API.
+
+Without this plugin, you would have to follow [these steps](https://web.hypothes.is/help/embedding-hypothesis-in-websites-and-platforms/), but with this plugin you only need to check some checkboxes, and you will be good to go.
+
+* [Terms of Service](https://web.hypothes.is/terms-of-service/)
+* [Privacy Policy](https://web.hypothes.is/privacy/)
+
 == Installation ==
 
 1. Upload `hypothesis.php` to the `/wp-content/plugins/` directory

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ An open platform for the collaborative evaluation of knowledge.
 
 Hypothesis is a web annotation tool that allows users to provide commentary, references, and insight on top of news, blogs, scientific articles, books, terms of service, ballot initiatives, legislation and regulations, software code and more. You can find out more at [http://hypothes.is/](http://hypothes.is/)
 
-This plugin will allow you to automatically embed Hypothesis in your site, and integrate with the Hypothesis annotations API.
+This plugin will allow you to automatically embed Hypothesis in your site.
 
 Without this plugin, you would have to follow [these steps](https://web.hypothes.is/help/embedding-hypothesis-in-websites-and-platforms/), but with this plugin you only need to check some checkboxes, and you will be good to go.
 


### PR DESCRIPTION
Part of #40 

This PR fixes the issues reported by the WordPress plugins team on their latest review.

- They reported an incorrect license used in the `License` field, and that a GPL-compatible one has to be used. I updated it from `BSD` to `BSD-2-Clause`, just in case only the identifier is wrong, as BSD appears as a GPL-compatible license.
  However, I have asked them to clarify if this is the probelm.
- I documented the integration with a third party, as we load the embed.js script from https://hypothes.is/embed.js
  This is allowed, but it needs to be explicitly noted in the readme.txt file.
  I also added links to our terms of service and privacy policy.
- I added a unique `Hypothesis` [PHP namespace](https://www.php.net/manual/en/language.namespaces.php) to our code, to avoid symbol name collisions with the global namespace that WordPress uses for its own internal API.