### PR TITLE
Migrate to BSD-3-Clause license for WordPress guidelines compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ Create a [new GitHub release](https://github.com/hypothesis/wp-hypothesis/releas
 
 ## License
 
-[BSD-2-Clause](http://opensource.org/licenses/BSD-2-Clause)
+[BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause)

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
       "source": "https://github.com/hypothesis/wp-hypothesis/"
     },
     "type": "wordpress-plugin",
-    "license": "BSD-2-Clause",
+    "license": "BSD-3-Clause",
     "require": {
         "php": ">=7.4"
     },

--- a/hypothesis.php
+++ b/hypothesis.php
@@ -8,8 +8,8 @@
  * Requires PHP: 7.4
  * Author: The Hypothesis Project and contributors
  * Author URI: https://hypothes.is/
- * License: BSD-2-Clause
- * License URI: https://opensource.org/licenses/BSD-2-Clause
+ * License: BSD-3-Clause
+ * License URI: https://opensource.org/licenses/BSD-3-Clause
  * Text Domain: hypothesis
  * Domain Path: /languages
  **/

--- a/license.txt
+++ b/license.txt
@@ -8,6 +8,9 @@ modification, are permitted provided that the following conditions are met:
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
+3. The name of the author may not be used to
+   endorse or promote products derived from this software without
+   specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "main": "Gruntfile.js",
   "author": "The Hypothesis Project and contributors",
   "repository": "http://github.com/hypothesis/wp-hypothesis/",
-  "license": "BSD-2-Clause",
+  "license": "BSD-3-Clause",
   "devDependencies": {}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Tags: hypothesis, annotation, comments
 Requires at least: 6.2
 Tested up to: 6.4.2
 Stable tag: 0.7.1
-License: BSD-2-Clause
-License URI: http://opensource.org/licenses/BSD-2-Clause
+License: BSD-3-Clause
+License URI: http://opensource.org/licenses/BSD-3-Clause
 
 An open platform for the collaborative evaluation of knowledge.
 


### PR DESCRIPTION
Part of #40 

Apparently the BSD-2-Clause license is not considered GPL-compatible by the WordPress plugins team.

Migrating to GPL-3-Clause, as that's explicitly listed in https://www.gnu.org/licenses/license-list.en.html