### PR TITLE
Document support for WordPress 6.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   wordpress:
-    image: wordpress:6.4-apache
+    image: wordpress:6.5-apache
     ports:
       - '8080:80'
     environment:

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: timmmmyboy, BigBlueHat, JakeHartnell, greatislander, acelaya
 Tags: hypothesis, annotation, comments
 Requires at least: 6.2
-Tested up to: 6.4.2
+Tested up to: 6.5.2
 Stable tag: 0.7.3
 License: BSD-3-Clause
 License URI: http://opensource.org/licenses/BSD-3-Clause


### PR DESCRIPTION
Following an email from WordPress, document support for v6.5, which was released a couple weeks ago.

I updated the dev env and did a quick manual testing.