### PR TITLE
Update most recently supported WordPress version to 6.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   wordpress:
-    image: wordpress:6.5-apache
+    image: wordpress:beta-6.8-apache
     ports:
       - '8080:80'
     environment:

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: timmmmyboy, BigBlueHat, JakeHartnell, greatislander, acelaya
 Tags: hypothesis, annotation, comments
 Requires at least: 6.2
-Tested up to: 6.5.2
+Tested up to: 6.8.0
 Stable tag: 0.7.3
 License: BSD-3-Clause
 License URI: http://opensource.org/licenses/BSD-3-Clause


### PR DESCRIPTION
In preparation for the upcoming WordPress 6.8 release, this PR updates the version used locally in dev envs (used to actually test the plugin compatibility), and documents the plugin has been tested up to that version.